### PR TITLE
feature/MING-27-회원가입-페이지-보강

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,14 @@ import RegisterPage from './pages/RegisterPage'
 import LostPassword from './pages/LostPassword'
 import MyPage from './pages/MyPage'
 import MingNavBar from './components/MingNavBar'
+import { useSelector } from 'react-redux'
+import { RootState } from './store'
 
 const App = () => {
+  const { auth } = useSelector((state: RootState) => state)
   return (
     <Routes>
-      <Route element={<MingNavBar />}>
+      <Route element={<MingNavBar memberInfo={auth.memberInfo} />}>
         <Route index element={<MainPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,0 +1,15 @@
+import { Token } from '../store/register/register.types'
+import { AxiosResponse } from 'axios'
+import { MemberInfo } from '../store/auth/auth.types'
+import client from './client'
+
+const HEADER = 'X-WWW-MING-AUTHORIZATION'
+export const memberInfo = (
+  token: Token,
+): Promise<AxiosResponse<{ result: MemberInfo }>> => {
+  return client.get('/api/members/info', {
+    headers: {
+      [HEADER]: token.accessToken,
+    },
+  })
+}

--- a/src/components/MingNavBar.tsx
+++ b/src/components/MingNavBar.tsx
@@ -1,13 +1,30 @@
 import { Container, Nav, Navbar } from 'react-bootstrap'
 import { Outlet } from 'react-router-dom'
+import { FC } from 'react'
+import { MemberInfo } from '../store/auth/auth.types'
 
-const MingNavBar = () => {
+const MingNavBar: FC<{
+  memberInfo: MemberInfo | null
+}> = ({ memberInfo }) => {
   return (
     <>
       <Navbar bg="black" variant="black">
         <Container>
           <Navbar.Brand href="#home">Ming! Commerce</Navbar.Brand>
           <Nav className="me-auto"></Nav>
+          {memberInfo && (
+            <div>
+              <a className="navbar-tool ms-1 ms-lg-0 me-n1 me-lg-2" href="#">
+                <div className="navbar-tool-icon-box">
+                  <i className="navbar-tool-icon ci-user"></i>
+                </div>
+                <div className="navbar-tool-text ms-n2">
+                  <small>안녕하세요.</small>
+                  {memberInfo.memberName}님
+                </div>
+              </a>
+            </div>
+          )}
         </Container>
       </Navbar>
       <Outlet />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,29 @@ import reportWebVitals from './reportWebVitals'
 import { BrowserRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { store } from './store'
+import { getMemberInfo, setTempMemberInfo } from './store/auth/auth.slice'
+import { MemberInfo } from './store/auth/auth.types'
+
+const loadMemberInfo = () => {
+  try {
+    // memberInfo 가 있는 경우
+    const memberInfo = localStorage.getItem('memberInfo')
+    const token = localStorage.getItem('token')
+    if (memberInfo) {
+      store.dispatch(setTempMemberInfo(JSON.parse(memberInfo) as MemberInfo))
+      // @ts-ignore
+      store.dispatch(getMemberInfo())
+    } else if (token) {
+      // @ts-ignore
+      store.dispatch(getMemberInfo())
+    } else return
+  } catch {
+    console.log('에러가 발생하였습니다.')
+  }
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+loadMemberInfo()
 root.render(
   <React.StrictMode>
     <Provider store={store}>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -5,12 +5,13 @@ import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from '../store'
 import {
   checkEmail,
-  registerUser,
+  registerMember,
   reset,
   set,
 } from '../store/register/register.slice'
 import { useNavigate } from 'react-router-dom'
 import { passwordCondition } from '../store/register/register.types'
+import { getMemberInfo } from '../store/auth/auth.slice'
 
 const RegisterPage = () => {
   const navigate = useNavigate()
@@ -18,6 +19,8 @@ const RegisterPage = () => {
   const { registerRequest, emailCheck, errorMessage, token } = useSelector(
     (state: RootState) => state.register,
   )
+
+  const { memberInfo } = useSelector((state: RootState) => state.auth)
 
   useEffect(() => {
     dispatch(reset())
@@ -47,19 +50,20 @@ const RegisterPage = () => {
     console.log(registerRequest)
 
     // @ts-ignore
-    dispatch(registerUser(registerRequest))
+    dispatch(registerMember(registerRequest))
   }
 
   useEffect(() => {
     if (token) {
-      //TODO 가입 완료 후 로직.
-      // localStorage에 토큰까지 저장 완료.
-      // @yeonnex 님이 토큰을 사용하여 사용자 정보 조회 API 로직 만들면 추가 로직 필요.
+      // @ts-ignore
+      dispatch(getMemberInfo())
+    }
+    if (memberInfo) {
       navigate('/', {
         replace: true,
       })
     }
-  }, [navigate, token])
+  }, [dispatch, navigate, token, memberInfo])
 
   return (
     <Container style={{ marginTop: '20px' }}>

--- a/src/store/auth/auth.slice.ts
+++ b/src/store/auth/auth.slice.ts
@@ -1,0 +1,50 @@
+import {
+  AsyncThunk,
+  createAsyncThunk,
+  createSlice,
+  PayloadAction,
+} from '@reduxjs/toolkit'
+import { MemberInfo } from './auth.types'
+import { memberInfo } from '../../api/auth.api'
+
+const initialState: { memberInfo: MemberInfo | null } = {
+  memberInfo: null,
+}
+export const getMemberInfo: AsyncThunk<MemberInfo, any, any> = createAsyncThunk(
+  'registerSlice/memberInfo',
+  async () => {
+    const token = localStorage.getItem('token')
+    if (!token) throw Error('No Token')
+    const response = await memberInfo(JSON.parse(token))
+    return response.data.result
+  },
+)
+
+const authSlice = createSlice({
+  name: 'authSlice',
+  initialState,
+  reducers: {
+    setTempMemberInfo: (state, action: PayloadAction<MemberInfo>) => {
+      state.memberInfo = action.payload
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(getMemberInfo.fulfilled, (state, action) => {
+      state.memberInfo = action.payload
+      localStorage.setItem('memberInfo', JSON.stringify(action.payload))
+    })
+
+    builder.addCase(getMemberInfo.rejected, (state, action) => {
+      try {
+        localStorage.removeItem('token')
+        localStorage.removeItem('memberInfo')
+      } catch {
+        console.log('에러 발생')
+      }
+    })
+  },
+})
+
+export default authSlice.reducer
+
+export const { setTempMemberInfo } = authSlice.actions

--- a/src/store/auth/auth.types.ts
+++ b/src/store/auth/auth.types.ts
@@ -1,0 +1,4 @@
+export type MemberInfo = {
+  email: string
+  memberName: string
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
 import registerReducer from './register/register.slice'
+import authReducer from './auth/auth.slice'
 
 export const store = configureStore({
   reducer: {
     register: registerReducer,
+    auth: authReducer,
   },
 })
 

--- a/src/store/register/register.slice.ts
+++ b/src/store/register/register.slice.ts
@@ -39,7 +39,7 @@ export const checkEmail: AsyncThunk<EmailCheckResponse, string, any> =
     return response.data
   })
 
-export const registerUser: AsyncThunk<Token, RegisterRequest, any> =
+export const registerMember: AsyncThunk<Token, RegisterRequest, any> =
   createAsyncThunk('registerSlice/register', async (arg, thunkAPI) => {
     const response = await registerApi.register(arg)
     return response.data
@@ -83,16 +83,18 @@ const registerSlice = createSlice({
         state.errorMessage.email = ''
       }
     })
+
     builder.addCase(checkEmail.rejected, (state) => {
       state.errorMessage.email = '일시적인 서버 오류가 발생하였습니다.'
       state.emailCheck = false
     })
 
-    builder.addCase(registerUser.fulfilled, (state, action) => {
+    builder.addCase(registerMember.fulfilled, (state, action) => {
       state.token = action.payload
       localStorage.setItem('token', JSON.stringify(action.payload))
     })
-    builder.addCase(registerUser.rejected, (state, action) => {
+
+    builder.addCase(registerMember.rejected, (state, action) => {
       console.log('회원가입 실패')
       console.log(state, action)
     })

--- a/src/store/register/register.types.ts
+++ b/src/store/register/register.types.ts
@@ -28,11 +28,9 @@ export type RegisterType = {
   }
   token: Token | null
 }
-
 export type EmailCheckResponse = {
   isDuplicated: boolean
 }
-
 export type Token = {
   accessToken: string
   refreshToken: string


### PR DESCRIPTION
## 개발 상세 내용

회원가입 후 받은 토큰을 사용하여 회원 정보를 조회한 후, 회원 정보가 성공적으로 조회 되었다면 정상적으로 회원가입 되었다고 판단한 후 메인화면으로 리다이렉트 하게 하였습니다.

또한 조회한 회원정보를 로컬 스토리지에 저장하여 새로고침 하여도 회원 정보를 보여줄 수 있게 하였습니다.
(물론 새로고침하면 다시 회원 조회 API를 호출하여 로컬 스토리지에 최신 회원 정보로 바꿔치게 됩니다. 로컬 스토리지에 저장한 이유는 추후 새로고침하게 되어 다시 회원 조회 API를 호출하게 되어도, 호출 하는 동안 회원가입 버튼 등을 노출하지 않게 하기 위한 전략입니다.)

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [회원가입 페이지 보강](https://ming-commerce.atlassian.net/browse/MING-27?atlOrigin=eyJpIjoiYzliZDg2MzNmY2ExNDIyYzg4NTMxZTY0MmE0NjQyOWMiLCJwIjoiaiJ9)

## 테스트 방법을 적습니다.(필요시)

백엔드를 구동시킨 상태로 해당 커밋을 풀 받은 후 회원가입을 해봅니다.
회원가입이 완료되면 메인 화면으로 리다이렉트 하게 되고, 새로고침을 해도 상단의 네비게이션 바에는 사용자 정보가 남아있게 됩니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11
