### PR TITLE
feature/MING-48-상품-주문-후-토스-결제창-호출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@tosspayments/payment-sdk": "^1.4.0",
     "axios": "^1.2.2",
     "bootstrap": "^5.2.3",
     "prettier": "^2.8.2",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
-import App from './App'
-
-test('renders learn react link', () => {
-  render(<App />)
-  const linkElement = screen.getByText(/learn react/i)
-  expect(linkElement).toBeInTheDocument()
-})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import MyPage from './pages/MyPage'
 import MingNavBar from './components/MingNavBar'
 import ProductDetailPage from './pages/ProductDetailPage'
 import CartPage from './pages/CartPage'
+import OrderRedirectPage from './pages/OrderRedirectPage'
 
 const App = () => {
   return (
@@ -20,6 +21,7 @@ const App = () => {
         <Route path="/products/:productId" element={<ProductDetailPage />} />
         <Route path="/cart" element={<CartPage />} />
       </Route>
+      <Route path="/order_redirect" element={<OrderRedirectPage />} />
     </Routes>
   )
 }

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -4,7 +4,6 @@ import { MemberInfo } from '../store/auth/auth.types'
 import client from './client'
 import { LoginRequest } from '../pages/LoginPage'
 
-const HEADER = 'X-WWW-MING-AUTHORIZATION'
 export const memberInfo = (): Promise<
   AxiosResponse<{ result: MemberInfo }>
 > => {

--- a/src/api/order.api.ts
+++ b/src/api/order.api.ts
@@ -1,0 +1,9 @@
+import { OrderRequest, OrderResponse } from '../store/order/order.types'
+import client from './client'
+import { AxiosResponse } from 'axios'
+
+export const order = (
+  request: OrderRequest,
+): Promise<AxiosResponse<OrderResponse>> => {
+  return client.post('/api/orders/order', request)
+}

--- a/src/pages/OrderRedirectPage.tsx
+++ b/src/pages/OrderRedirectPage.tsx
@@ -1,0 +1,50 @@
+import { useSearchParams } from 'react-router-dom'
+import { Col, Container, Row, Spinner } from 'react-bootstrap'
+
+const OrderRedirectPage = () => {
+  const [searchParams] = useSearchParams()
+  const orderId = searchParams.get('orderId') as string
+  const paymentKey = searchParams.get('paymentKey') as string
+  const amount = Number(searchParams.get('amount'))
+  console.log(orderId)
+  console.log(paymentKey)
+  console.log(amount)
+  return (
+    <Container fluid="md">
+      <Row className="justify-content-center">
+        <Col className="text-center">
+          <Spinner
+            variant="primary"
+            style={{ width: '300px', height: '300px' }}
+          />
+        </Col>
+      </Row>
+      <Row className="justify-content-center">
+        <Col className="text-center">결제중입니다.</Col>
+      </Row>
+      <Row>
+        <Col className="text-center">
+          ### 여기서 결제 API 호출, 결제 완료 후 주문 완료 창으로 다시
+          리다이렉트 ###
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <span className="fw-bold">orderId:</span> {orderId}
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <span className="fw-bold">paymentKey:</span> {paymentKey}
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <span className="fw-bold">amount:</span> {amount}
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+export default OrderRedirectPage

--- a/src/store/order/order.types.ts
+++ b/src/store/order/order.types.ts
@@ -1,0 +1,9 @@
+export type OrderRequest = {
+  cartLineUuidList: Array<string>
+}
+
+export type OrderResponse = {
+  orderId: string
+  amount: number
+  orderName: string
+}


### PR DESCRIPTION
## 개발 상세 내용

상품 주문 후 토스 결제창 호출하는 로직을 구현하였습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [상품 주문 후 토스 결제창 호출](https://ming-commerce.atlassian.net/browse/MING-48?atlOrigin=eyJpIjoiMzRlODliNzRhZjI0NDRhYzhkY2E5N2M4OTAzYzVkMzAiLCJwIjoiaiJ9)

## 테스트 방법을 적습니다.(필요시)

백엔드 및 프론트엔드 프로젝트 구동 후, 로그인 -> 상품 카트에 담기 -> 주문 순으로 진행합니다.

주문 API 호출이 성공하면 토스SDK를 사용하여 결제창을 띄우게 됩니다. (실제로 돈이 나가지 않는 테스트 결제입니다.)

토스로 결제 후에 리다이렉트 페이지로 이동하는지 테스트 합니다.

또한 리다이렉트 페이지에 주문번호, 결제키, 주문총액이 제대로 넘어오는지도 확인합니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11
