### PR TITLE
feature/MING-67-마이페이지-내의-주문-조회-페이지-구현

### DIFF
--- a/src/api/order.api.ts
+++ b/src/api/order.api.ts
@@ -1,13 +1,12 @@
-import { OrderRequest, OrderResponse } from '../store/order/order.types'
+import {
+  MyOrderWrapper,
+  OrderRequest,
+  OrderResponse,
+  OrderResult,
+} from '../store/order/order.types'
 import client from './client'
 import { AxiosResponse } from 'axios'
 
-export type OrderResult = {
-  orderId: string
-  amount: number
-  orderName: string
-  orderStatus: string
-}
 export const order = (
   request: OrderRequest,
 ): Promise<AxiosResponse<OrderResponse>> => {
@@ -22,4 +21,11 @@ export const getOrder = (
       orderId,
     },
   })
+}
+
+export const getMyOrder = (
+  page: number,
+  size: number,
+): Promise<AxiosResponse<MyOrderWrapper>> => {
+  return client.get(`/api/orders/my-order?page=${page - 1}&size=${size}`)
 }

--- a/src/components/MyOrderCard.tsx
+++ b/src/components/MyOrderCard.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+import { MyOrder } from '../store/order/order.types'
+import { Card, Col, Row } from 'react-bootstrap'
+
+export const MyOrderCard: FC<{ order: MyOrder }> = ({ order }) => {
+  return (
+    <Card
+      className="product-card card-static shadow"
+      style={{ margin: '10px' }}
+    >
+      <Row>
+        <Col xs={3}>
+          <Card.Img
+            variant="top"
+            className="ms-3 mt-3"
+            style={{
+              width: '50px',
+              height: '50px',
+            }}
+            src={order.thumbnailImageUrl}
+            alt={order.orderName}
+          />
+        </Col>
+        <Col className="me-4" style={{ fontSize: 'small' }}>
+          <Row>{order.orderName}</Row>
+          <Row className="text-primary justify-content-end">
+            {order.totalAmount.toLocaleString()}원
+          </Row>
+        </Col>
+      </Row>
+    </Card>
+  )
+}

--- a/src/components/MyOrderList.tsx
+++ b/src/components/MyOrderList.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react'
+import { MyOrder } from '../store/order/order.types'
+import { MyOrderCard } from './MyOrderCard'
+
+const MyOrderList: FC<{ myOrders: Array<MyOrder> }> = ({ myOrders }) => {
+  return (
+    <>
+      {myOrders.map((order) => (
+        <MyOrderCard order={order} key={order.orderId} />
+      ))}
+    </>
+  )
+}
+
+export default MyOrderList

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,23 +1,71 @@
 import { useSelector } from 'react-redux'
 import { RootState } from '../store'
-import { Button, Container } from 'react-bootstrap'
+import { Button, Col, Container, ListGroup, Row } from 'react-bootstrap'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getMyOrder } from '../api/order.api'
+import { MyOrder } from '../store/order/order.types'
+import MyOrderList from '../components/MyOrderList'
 
+const MY_ORDER_SIZE = 5
 const MyPage = () => {
   const { memberInfo } = useSelector((state: RootState) => state.auth)
-  if (!memberInfo) return null
-  //TODO 유저 정보 API 사용 필요
+  const navigate = useNavigate()
+  const [myOrderList, setMyOrderList] = useState<Array<MyOrder>>([])
+  const [isLast, setIsLast] = useState(false)
+  const [page, setPage] = useState(1)
+  useEffect(() => {
+    if (!memberInfo) {
+      navigate('/', { replace: true })
+    }
+    getMyOrder(1, MY_ORDER_SIZE)
+      .then((response) => response.data)
+      .then((result) => {
+        setMyOrderList(result.content)
+        setIsLast(result.last)
+      })
+  }, [memberInfo, navigate])
 
   const onClickLogout = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('memberInfo')
     document.location.href = '/'
   }
+
+  const onClickMoreOrders = async () => {
+    const nextPage = page + 1
+    setPage(nextPage)
+    const response = await getMyOrder(nextPage, MY_ORDER_SIZE)
+    const nextMyOrders = response.data
+    setMyOrderList([...myOrderList, ...nextMyOrders.content])
+    setIsLast(nextMyOrders.last)
+  }
+
   return (
     <Container>
-      <h2 className="h2 mb-0 pt-3 me-3">My Page</h2>
+      <h1 className="mb-0 pt-3 me-3">My Page</h1>
       <Button variant="danger" onClick={onClickLogout}>
         로그아웃
       </Button>
+      <Row className="mx-n2 mt-5">
+        <Col>
+          <h2>나의 최근 주문목록</h2>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <ListGroup>
+            {myOrderList && <MyOrderList myOrders={myOrderList} />}
+          </ListGroup>
+        </Col>
+      </Row>
+      {!isLast && (
+        <Row className="ms-1 me-1">
+          <Button variant="warning" onClick={onClickMoreOrders}>
+            더보기
+          </Button>
+        </Row>
+      )}
     </Container>
   )
 }

--- a/src/pages/OrderCompletePage.tsx
+++ b/src/pages/OrderCompletePage.tsx
@@ -1,7 +1,8 @@
 import { Card, Container, ListGroup, ListGroupItem } from 'react-bootstrap'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { getOrder, OrderResult } from '../api/order.api'
+import { getOrder } from '../api/order.api'
+import { OrderResult } from '../store/order/order.types'
 
 const OrderCompletePage = () => {
   const { orderId } = useParams<{ orderId: string }>()

--- a/src/store/order/order.types.ts
+++ b/src/store/order/order.types.ts
@@ -7,3 +7,24 @@ export type OrderResponse = {
   amount: number
   orderName: string
 }
+
+export type MyOrder = {
+  orderId: string
+  orderName: string
+  thumbnailImageUrl: string
+  totalAmount: number
+}
+export type MyOrderWrapper = {
+  content: Array<MyOrder>
+  first: boolean
+  last: boolean
+  totalElements: number
+  totalPages: number
+}
+
+export type OrderResult = {
+  orderId: string
+  amount: number
+  orderName: string
+  orderStatus: string
+}


### PR DESCRIPTION
## 개발 상세 내용

마이페이지 안에서 사용자 주문 조회가 가능하도록 페이지를 구성하였습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [MING-67](https://ming-commerce.atlassian.net/browse/MING-67)

## 테스트 방법을 적습니다.(필요시)

어떻게 테스트를 진행해야 하는지 적습니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11


[MING-67]: https://ming-commerce.atlassian.net/browse/MING-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ