### PR TITLE
feature/MING-75-마이페이지-내의-사용자-주문-페이지에서-주문-일자-표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@tosspayments/payment-sdk": "^1.4.0",
     "axios": "^1.2.2",
     "bootstrap": "^5.2.3",
+    "moment": "^2.29.4",
     "prettier": "^2.8.2",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.0",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/jest": "^27.5.2",
+    "@types/moment": "^2.13.0",
     "@types/node": "^16.18.11",
     "@types/react": "^18.0.26",
     "@types/react-bootstrap": "^0.32.32",

--- a/src/components/MyOrderCard.tsx
+++ b/src/components/MyOrderCard.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react'
 import { MyOrder } from '../store/order/order.types'
 import { Card, Col, Row } from 'react-bootstrap'
+import moment from 'moment'
+import 'moment/locale/ko'
 
 export const MyOrderCard: FC<{ order: MyOrder }> = ({ order }) => {
   return (
@@ -23,6 +25,9 @@ export const MyOrderCard: FC<{ order: MyOrder }> = ({ order }) => {
         </Col>
         <Col className="me-4" style={{ fontSize: 'small' }}>
           <Row>{order.orderName}</Row>
+          <Row className="text-accent justify-content-end">
+            {moment(order.updatedDate).fromNow()} 주문
+          </Row>
           <Row className="text-primary justify-content-end">
             {order.totalAmount.toLocaleString()}원
           </Row>

--- a/src/store/order/order.types.ts
+++ b/src/store/order/order.types.ts
@@ -13,6 +13,7 @@ export type MyOrder = {
   orderName: string
   thumbnailImageUrl: string
   totalAmount: number
+  updatedDate: string
 }
 export type MyOrderWrapper = {
   content: Array<MyOrder>


### PR DESCRIPTION
## 개발 상세 내용

사용자 주문조회 페이지(마이페이지)에서 주문 일자도 표시하게 했습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [마이페이지 내의 사용자 주문 페이지에서 주문 일자 표시](https://ming-commerce.atlassian.net/browse/MING-75)

## 테스트 방법을 적습니다.(필요시)

어떻게 테스트를 진행해야 하는지 적습니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11
