### PR TITLE
feature/MING-76-마이페이지-내에-사용자-메일-변경-시-인증메일-보내는-기능-구현

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -15,3 +15,7 @@ export const login = (
 ): Promise<AxiosResponse<Token>> => {
   return client.post('/api/login', loginRequest)
 }
+
+export const sendEmail = (request: { email: string }) => {
+  return client.post('/api/members/send-email', request)
+}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,19 +1,38 @@
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from '../store'
-import { Button, Col, Container, ListGroup, Row } from 'react-bootstrap'
-import { useEffect, useState } from 'react'
+import {
+  Alert,
+  Button,
+  Col,
+  Container,
+  Form,
+  ListGroup,
+  Row,
+} from 'react-bootstrap'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getMyOrder } from '../api/order.api'
 import { MyOrder } from '../store/order/order.types'
 import MyOrderList from '../components/MyOrderList'
+import { checkEmail, reset } from '../store/register/register.slice'
+import { sendEmail } from '../api/auth.api'
 
 const MY_ORDER_SIZE = 5
 const MyPage = () => {
   const { memberInfo } = useSelector((state: RootState) => state.auth)
   const navigate = useNavigate()
+  const dispatch = useDispatch()
   const [myOrderList, setMyOrderList] = useState<Array<MyOrder>>([])
   const [isLast, setIsLast] = useState(false)
   const [page, setPage] = useState(1)
+  const { emailCheck, errorMessage } = useSelector(
+    (state: RootState) => state.register,
+  )
+  const [email, setEmail] = useState('')
+  const [sendSuccess, setSendSuccess] = useState(false)
+  useEffect(() => {
+    dispatch(reset())
+  }, [dispatch])
   useEffect(() => {
     if (!memberInfo) {
       navigate('/', { replace: true })
@@ -41,12 +60,70 @@ const MyPage = () => {
     setIsLast(nextMyOrders.last)
   }
 
+  const onChangeEmail = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = target
+    if (/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/g.test(value)) {
+      // @ts-ignore
+      dispatch(checkEmail(value))
+    }
+    setEmail(value)
+  }
+
+  const onClickChangeEmail = async () => {
+    const response = await sendEmail({ email })
+    if (response.status === 200) setSendSuccess(true)
+  }
+
   return (
     <Container>
       <h1 className="mb-0 pt-3 me-3">My Page</h1>
       <Button variant="danger" onClick={onClickLogout}>
         로그아웃
       </Button>
+      <Row className="mx-n2 mt-5">
+        <Col>
+          <h2>사용자 정보 변경</h2>
+          <Form.Group className="mb-3">
+            <Form.Label>이메일 주소</Form.Label>
+            <Form.Control
+              type="email"
+              name="email"
+              value={email}
+              onChange={onChangeEmail}
+              placeholder="이메일을 입력해주세요."
+            />
+            <Alert
+              show={emailCheck !== null && emailCheck}
+              className="small"
+              variant="success"
+            >
+              사용 가능한 이메일입니다.
+            </Alert>
+            <Alert
+              className="small"
+              show={errorMessage.email.length > 0}
+              variant="danger"
+            >
+              {errorMessage.email}
+            </Alert>
+            <Alert className="small" show={sendSuccess} variant="info">
+              {email} 로 인증 메일을 보냈습니다.
+            </Alert>
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <div className="d-grid gap-2">
+              <Button
+                variant="primary"
+                size="lg"
+                disabled={!emailCheck}
+                onClick={onClickChangeEmail}
+              >
+                변경하기
+              </Button>
+            </div>
+          </Form.Group>
+        </Col>
+      </Row>
       <Row className="mx-n2 mt-5">
         <Col>
           <h2>나의 최근 주문목록</h2>

--- a/src/store/register/register.slice.ts
+++ b/src/store/register/register.slice.ts
@@ -78,7 +78,7 @@ const registerSlice = createSlice({
       // 이미 중복 되었으면
       if (isDuplicated) {
         state.emailCheck = false
-        state.errorMessage.email = `${state.registerRequest.email}은 이미 사용중인 이메일입니다.`
+        state.errorMessage.email = `이미 사용중인 이메일입니다.`
       } else {
         state.emailCheck = true
         state.errorMessage.email = ''


### PR DESCRIPTION
## 개발 상세 내용

마이 페이지 내에서 사용자 이메일 변경 인증 메일 발송 기능 구현

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [마이페이지 내에 사용자 메일 변경 시 인증메일 보내는 기능 구현](https://ming-commerce.atlassian.net/browse/MING-76)

## 테스트 방법을 적습니다.(필요시)

어떻게 테스트를 진행해야 하는지 적습니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11
