### PR TITLE
feature/MING-78-인증메일-링크가-이동하는-페이지-구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ProductDetailPage from './pages/ProductDetailPage'
 import CartPage from './pages/CartPage'
 import OrderRedirectPage from './pages/OrderRedirectPage'
 import OrderCompletePage from './pages/OrderCompletePage'
+import UserUpdateLinkPage from './pages/UserUpdateLinkPage'
 
 const App = () => {
   return (
@@ -24,6 +25,7 @@ const App = () => {
         </Route>
         <Route path="/products/:productId" element={<ProductDetailPage />} />
         <Route path="/cart" element={<CartPage />} />
+        <Route path="/update-user" element={<UserUpdateLinkPage />} />
       </Route>
       <Route path="/order_redirect" element={<OrderRedirectPage />} />
     </Routes>

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -19,3 +19,12 @@ export const login = (
 export const sendEmail = (request: { email: string }) => {
   return client.post('/api/members/send-email', request)
 }
+
+export const changeEmail = (request: {
+  email: string
+  token: string
+}): Promise<AxiosResponse<Token>> => {
+  return client.get(
+    `/api/members/change-email?token=${request.token}&email=${request.email}`,
+  )
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,5 @@
-import { Container } from 'react-bootstrap'
-import { useEffect } from 'react'
+import { Alert, Container } from 'react-bootstrap'
+import { useEffect, useState } from 'react'
 import ProductList from '../api/ProductList'
 import { useDispatch, useSelector } from 'react-redux'
 import { RootState } from '../store'
@@ -10,8 +10,17 @@ const MainPage = () => {
   const { loading, productList } = useSelector(
     (state: RootState) => state.product.list,
   )
-
   const dispatch = useDispatch()
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    const message = localStorage.getItem('message') as string
+    if (message) {
+      setMessage(message)
+      localStorage.removeItem('message')
+    }
+  }, [])
+
   useEffect(() => {
     // @ts-ignore
     dispatch(
@@ -22,6 +31,11 @@ const MainPage = () => {
 
   return (
     <Container>
+      {message && (
+        <Alert variant="info" className="mt-4 pt-3 me-3">
+          {message}
+        </Alert>
+      )}
       <h2 className="h3 mb-0 pt-3 me-3">Bestsellers</h2>
       <hr />
       <ProductList loading={loading} productList={productList} />

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -16,6 +16,8 @@ import { MyOrder } from '../store/order/order.types'
 import MyOrderList from '../components/MyOrderList'
 import { checkEmail, reset } from '../store/register/register.slice'
 import { sendEmail } from '../api/auth.api'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { AxiosError } from 'axios'
 
 const MY_ORDER_SIZE = 5
 const MyPage = () => {
@@ -30,6 +32,8 @@ const MyPage = () => {
   )
   const [email, setEmail] = useState('')
   const [sendSuccess, setSendSuccess] = useState(false)
+  const [sendFail, setSendFail] = useState(false)
+  const [sendFailMessage, setSendFailMessage] = useState('')
   useEffect(() => {
     dispatch(reset())
   }, [dispatch])
@@ -70,8 +74,19 @@ const MyPage = () => {
   }
 
   const onClickChangeEmail = async () => {
-    const response = await sendEmail({ email })
-    if (response.status === 200) setSendSuccess(true)
+    try {
+      const response = await sendEmail({ email })
+      if (response.status === 200) {
+        setSendSuccess(true)
+        setSendFail(false)
+      }
+      // @ts-ignore
+    } catch (err: AxiosError) {
+      const { message } = err.response.data
+      setSendFailMessage(message)
+      setSendSuccess(false)
+      setSendFail(true)
+    }
   }
 
   return (
@@ -108,6 +123,9 @@ const MyPage = () => {
             </Alert>
             <Alert className="small" show={sendSuccess} variant="info">
               {email} 로 인증 메일을 보냈습니다.
+            </Alert>
+            <Alert className="small" show={sendFail} variant="danger">
+              {sendFailMessage}
             </Alert>
           </Form.Group>
           <Form.Group className="mb-3">

--- a/src/pages/UserUpdateLinkPage.tsx
+++ b/src/pages/UserUpdateLinkPage.tsx
@@ -1,0 +1,46 @@
+import { Container } from 'react-bootstrap'
+import { FC, useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { changeEmail } from '../api/auth.api'
+import { getMemberInfo } from '../store/auth/auth.slice'
+import { useDispatch } from 'react-redux'
+
+const UserUpdateLinkPage: FC = () => {
+  const [searchParams] = useSearchParams()
+  const [token, setToken] = useState<string | undefined | null>('')
+  const [email, setEmail] = useState<string | undefined | null>('')
+  const navigate = useNavigate()
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    const token = searchParams.get('token') as string
+    const email = searchParams.get('email') as string
+    setToken(token)
+    setEmail(email)
+    console.log(token, email)
+  }, [searchParams])
+
+  useEffect(() => {
+    if (!token || !email) return
+    changeEmail({ email, token })
+      .then((response) => response.data)
+      .then((token) => {
+        localStorage.setItem('token', JSON.stringify(token))
+        // @ts-ignore
+        dispatch(getMemberInfo())
+        localStorage.setItem('message', `이메일이 ${email}로 변경되었습니다.`)
+        navigate('/', { replace: true })
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }, [token, email, navigate])
+
+  return (
+    <Container>
+      <h1 className="mb-0 pt-3 me-3">사용자 변경 인증</h1>
+    </Container>
+  )
+}
+
+export default UserUpdateLinkPage


### PR DESCRIPTION
## 개발 상세 내용

인증메일 링크 이동 페이지 구현 및 이메일 인증횟수 제한 에러 메시지 노출시키는 작업을 진행하였습니다.

## Jira Ticket (지라 이슈 번호를 적어 연결합니다.)

- [인증메일 링크가 이동하는 페이지 구현](https://ming-commerce.atlassian.net/browse/MING-78)

## 테스트 방법을 적습니다.(필요시)

해당 브랜치를 pull 받으신 후, 로컬에서 사용자 이메일 인증 요청을 여러번 해봅니다.
- 에러 메시지가 표시되어야 합니다.

받은 이메일 인증 링크를 복사한 후, 앞의 운영 도메인을 localhost에 3000번 포트로 바꾼 후에 들어가봅니다.
- 이메일 변경이 일어나야 하며, 리다이렉트 된 메인 페이지에는 변경 안내 메시지가 표시되어야 합니다.

## PR 요청시 테스트해야 하는 항목을 적고 테스트한 내용을 체크합니다.

- [ ] (필요한 경우) `lint`에 통과
- [ ] (필요한 경우) `유닛 테스트`에 통과
- [ ] 다음 기능에 대한 테스트를 포함
    - [ ] 입력 기능 (Insert)
    - [ ] 수정 기능 (Update)
    - [ ] 삭제 기능 (Delete)
    - [ ] 조회 기능 (Select)
- [ ] 브라우저별 테스트를 진행
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Safari
    - [ ] IE 11
